### PR TITLE
Fix: Add kernel version check for unaligned header inclusion

### DIFF
--- a/driver/ch9344.c
+++ b/driver/ch9344.c
@@ -62,7 +62,12 @@
 #include <linux/timer.h>
 #include <linux/kfifo.h>
 #include <asm/byteorder.h>
-#include <asm/unaligned.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+#include <asm/unaligned.h>  // For kernels before 6.12
+#else
+#include <linux/unaligned.h>  // For kernels 6.12 and above
+#endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0))
 #include <linux/sched/signal.h>


### PR DESCRIPTION
Fix for issue #33 , driven by the answer of @MrElendig from [this thread](https://github.com/DIGImend/digimend-kernel-drivers/issues/706) and [this post](https://lkml.org/lkml/2024/10/6/423). 